### PR TITLE
Ajout des filtres et récupération des types de capteurs

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -18,8 +18,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-
-
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("web.urls")),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ Django==5.1.4
 django-ninja==1.3.0
 django-tailwind==3.8.0
 idna==3.10
+influxdb-client==1.48.0
 Jinja2==3.1.5
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
@@ -19,8 +20,11 @@ pydantic==2.10.4
 pydantic_core==2.27.2
 Pygments==2.19.1
 python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
 python-slugify==8.0.4
+pytz==2024.2
 PyYAML==6.0.2
+reactivex==4.0.4
 requests==2.32.3
 rich==13.9.4
 six==1.17.0
@@ -29,4 +33,3 @@ text-unidecode==1.3
 types-python-dateutil==2.9.0.20241206
 typing_extensions==4.12.2
 urllib3==2.3.0
-python-dotenv

--- a/backend/services/influxdb_client_django.py
+++ b/backend/services/influxdb_client_django.py
@@ -5,7 +5,7 @@ import pytz
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-from backend.backend import settings
+from backend import settings
 
 @dataclass
 class listCapteur:

--- a/backend/services/influxdb_client_django.py
+++ b/backend/services/influxdb_client_django.py
@@ -31,16 +31,15 @@ class CapteurResult:
     def compare_to_other(self, other) -> bool:
         """
         Compare cette instance avec une autre instance de CapteurResult,
-        en ignorant les champs 'time' et 'time_fr'.
+        en ignorant les champs 'time' et 'time_fr', ainsi que value.
 
         :param other: Une autre instance de CapteurResult
-        :return: True si les champs (sauf time et time_fr) sont identiques, False sinon
+        :return: True si les champs (sauf time et time_fr et value) sont identiques, False sinon
         """
         if not isinstance(other, CapteurResult):
             raise TypeError("La comparaison est uniquement possible avec une autre instance de CapteurResult.")
         
         return (
-            self.value == other.value and
             self.field == other.field and
             self.room_id == other.room_id and
             self.sensor_id == other.sensor_id and
@@ -226,6 +225,8 @@ class InfluxDB:
             all_query += f'\n|> last()'
         if return_object:        
             result = self(all_query)
+            if(not result):
+                return []
             self._last_result = self.transform_json_to_dataclass(result)
             return self._last_result
 

--- a/backend/webapi/urls.py
+++ b/backend/webapi/urls.py
@@ -1,5 +1,12 @@
 from django.urls import path
-from .views import router;
+from .views import router, router2;
+from ninja import NinjaAPI
+
+api = NinjaAPI()
+
+api.add_router("/sensors", router, tags=["sensors"])
+api.add_router("/sensors_types", router2, tags=["sensors_types"])
+
 urlpatterns = [
-    path("", router.urls),
+    path("", api.urls),  
 ]

--- a/backend/webapi/views.py
+++ b/backend/webapi/views.py
@@ -1,16 +1,27 @@
 from .models import SensorType
 from django.http import JsonResponse
-from ninja import NinjaAPI, Schema 
+from ninja import Router, Schema 
+from services.influxdb_client_django import CapteurResult, InfluxDB
 
 # Create your views here.
 class SensorTypeOut(Schema):
     fields: list
     description: str
 
+router = Router()
+router2 = Router()
 
-router = NinjaAPI()
+@router.get("", response={200: list[CapteurResult]})
+def get_all_last_sensors(request):
+    """
+    Récupère les dernières valeurs pour tous les capteurs.
+    """
+    # Initialisation de l'objet InfluxDB
+    db = InfluxDB()
+    db.get(return_object=True)
+    return db.get_all_last()
 
-@router.get("/sensors_types", response={200: dict[str, SensorTypeOut]})
+@router2.get("", response={200: dict[str, SensorTypeOut]})
 def get_sensor_types(request):
     """
     Récupère tous les types de capteurs depuis la base de données.

--- a/backend/webapi/views.py
+++ b/backend/webapi/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from .models import SensorType
 from django.http import JsonResponse
 from ninja import Router, Schema 
@@ -20,12 +21,24 @@ def get_all_last_sensors(request):
     
 
 @router.get("/{room_id}", response={200: list[CapteurResult]})
-def get_data_by_room(request, room_id: str, field: str = None):
-    if field:
-        result = db.get(room_id=[room_id], field=field, return_object=True)
-    else:
-        result = db.get(room_id=[room_id], return_object=True)
-    return db.get_all_last(result)
+def get_data_by_room(request, room_id: str, sensor_type: list[str] = None, field: str = None, start_time: str = None, end_time: str = None):
+
+    start_time_dt = None
+    end_time_dt = None
+
+    if start_time:
+        start_time_dt = datetime.fromisoformat(start_time).isoformat()  # Convertir en datetime puis en isoformat
+    if end_time:
+        end_time_dt = datetime.fromisoformat(end_time).isoformat() 
+
+
+    result = db.get(room_id=[room_id], sensor_type=sensor_type, start_time=start_time_dt, end_time=end_time_dt,  field=field, return_object=True)
+
+    if not result:
+        return []
+
+
+    return result
 
 
 @router2.get("", response={200: dict[str, SensorTypeOut]})

--- a/backend/webapi/views.py
+++ b/backend/webapi/views.py
@@ -8,18 +8,25 @@ class SensorTypeOut(Schema):
     fields: list
     description: str
 
+db = InfluxDB()
+
 router = Router()
 router2 = Router()
 
 @router.get("", response={200: list[CapteurResult]})
 def get_all_last_sensors(request):
-    """
-    Récupère les dernières valeurs pour tous les capteurs.
-    """
-    # Initialisation de l'objet InfluxDB
-    db = InfluxDB()
     db.get(return_object=True)
     return db.get_all_last()
+    
+
+@router.get("/{room_id}", response={200: list[CapteurResult]})
+def get_data_by_room(request, room_id: str, field: str = None):
+    if field:
+        result = db.get(room_id=[room_id], field=field, return_object=True)
+    else:
+        result = db.get(room_id=[room_id], return_object=True)
+    return db.get_all_last(result)
+
 
 @router2.get("", response={200: dict[str, SensorTypeOut]})
 def get_sensor_types(request):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     networks:
       - django_network
     environment:
-      - APP_API=http://192.168.210.74:8000/api
+      - APP_API=http://192.168.1.35:8000/api
     depends_on:
       - web
     profiles:


### PR DESCRIPTION
1. **Ajout de filtres de temps** : Permet de filtrer les données des capteurs par `start_time` et `end_time` dans la vue `get_data_by_room`. Si ces paramètres sont fournis, les données sont filtrées par plage horaire.

2. **Récupération des types de capteurs** : Ajout d'une nouvelle vue `get_sensor_types` qui retourne les types de capteurs, leurs champs et descriptions depuis la base de données.

3. **Formatage des dates** : Les dates `start_time` et `end_time` sont converties en format ISO 8601 pour être compatibles avec InfluxDB.

4. **Structure de réponse** : Les résultats des types de capteurs sont renvoyés sous forme de `JsonResponse`, organisés en dictionnaire avec les champs et descriptions.
